### PR TITLE
GenLens 2.0

### DIFF
--- a/src/main/scala/optics/poly/EPOptional.scala
+++ b/src/main/scala/optics/poly/EPOptional.scala
@@ -27,7 +27,7 @@ trait EPOptional[+E, -S, +T, +A, -B] extends EPTraversal[E, S, T, A, B] { self =
   def mapError[E1](update: E => E1): EPOptional[E1, S, T, A, B] =
     EPOptional[E1, S, T, A, B](getOrModify(_).left.map{ case (e, t) => (update(e), t)}, replace)
 
-  def some[A1, B1](implicit ev1: A <:< Option[A1], ev2: Option[B1] <:< B): EPOptional[E | String, S, T, A1, B1] =
+  def some[A1, B1](implicit ev1: A <:< Option[A1], ev2: Option[B1] <:< B): EPOptional[E | NoSuchElementException, S, T, A1, B1] =
     adapt >>> PPrism.some
 
   def adapt[A1, B1](implicit evA: A <:< A1, evB: B1 <:< B): EPOptional[E, S, T, A1, B1] =

--- a/src/main/scala/optics/poly/EPPrism.scala
+++ b/src/main/scala/optics/poly/EPPrism.scala
@@ -44,8 +44,8 @@ object PPrism {
   def apply[S, T, A, B](_getOrModify: S => Either[T, A], _reverseGet: B => T): PPrism[S, T, A, B] =
     EPPrism(_getOrModify(_).left.map(defaultError -> _), _reverseGet)
 
-  def some[A, B]: EPPrism[String, Option[A], Option[B], A, B] =
-    EPPrism.some("None is not a Some")
+  def some[A, B]: EPPrism[NoSuchElementException, Option[A], Option[B], A, B] =
+    EPPrism.some(NoSuchElementException("None is not a Some"))
 }
 
 object EPrism {

--- a/src/main/scala/optics/poly/GenLens.scala
+++ b/src/main/scala/optics/poly/GenLens.scala
@@ -1,6 +1,13 @@
 package optics.poly
 
+import functions.{Attempt, Index}
 import scala.quoted._
+import Function.const
+
+extension dsl {
+  def [A, Err, B] (a: A)?(using Attempt[A] { type To = B; type Error = Err }): B = ???
+  def [A, K, Err, B](a: A) idx (k: K)(using Index[A, K] { type To = B; type Error = Err }): B = ???
+}
 
 object GenLens {
 
@@ -11,7 +18,8 @@ object GenLens {
 
     object Function {
       def unapply(t: Term): Option[(List[ValDef], Term)] = t match {
-        case Inlined(None, Nil, Lambda(params, body)) => Some((params, body))
+        case Lambda(params, body) => Some((params, body))
+        case Inlined(_, Nil, body) => unapply(body)
         case _ => None
       }
     }
@@ -22,11 +30,10 @@ object GenLens {
           f(term, a)
         case outer @ Select(inner, name) =>
           f(outer, fold(inner)(a)(f))
-        case Apply(Apply(TypeApply(sym @ Ident("?"), _), rhs :: Nil), _) => {
-          fold(rhs)(a)(f)
-        }
-        case tree =>
-          qctx.error(s"Unrecognized syntax. $tree")
+        case Block(List(), Inlined(_, _, term)) =>
+          fold(term)(a)(f)
+        case _ =>
+          qctx.error(s"Unrecognized syntax in expression body.")
           a
       }
 
@@ -77,15 +84,200 @@ object GenLens {
           '{???}
         }
       case err =>
-        qctx.error(s"Unsupported syntax. Example: `GenLens[Address](_.streetNumber)`, $err")
+        qctx.error(s"Unsupported syntax. Example: `GenLens[Address](_.streetNumber)`, ${err.show}")
         '{???}
     }
   }
 
-  def apply[S] = new GenLens[S]
+  def apply[S] = new MkGenLens[S]
 
-  class GenLens[S] {
+  inline def uncurried[S, T](inline get: (S => T)): Lens[S, T] = ${ GenLens.impl('get )}
+
+  class MkGenLens[S] {
     inline def apply[T](inline get: (S => T)): Lens[S, T] = ${ GenLens.impl('get) }
   }
 
+}
+
+object Focus {
+
+  def impl[S: Type, T](getter: Expr[S => T])(using qctx: QuoteContext, ttt: Type[T]) = {
+
+    import qctx.tasty._
+    import util._
+
+    object Function {
+      def unapply(t: Term): Option[(Term)] = t match {
+        case Inlined(None, Nil, lambda @ Lambda(params, body)) => Some((lambda))
+        case _ => None
+      }
+    }
+
+    object Path {
+
+      private def recur(tree: Term, selects: List[String]): Option[(List[String], Term)] = tree match {
+        case Select(qual, name) => recur(qual, name :: selects)
+        // stop extraction at this stage
+        case expr if selects.nonEmpty => Some((selects, expr))
+        case _ => None
+      }
+
+      def unapply(t: Term): Option[(List[String], Term)] = recur(t, Nil)
+    }
+
+    object Operator0 {
+      def unapply(t: Term): Option[(Ident, List[TypeTree], Term, Term)] = t match {
+        case Apply(Apply(TypeApply(ident @ Ident(_), tpe), rhs :: Nil), witness :: Nil) =>
+          Some((ident, tpe, witness, rhs))
+        case _ => None
+      }
+    }
+
+    object Operator1 {
+      def unapply(t: Term): Option[(Ident, List[TypeTree], Term, Term, Term)] = t match {
+        case Apply(Apply(Apply(TypeApply(ident @ Ident(_), tpe), rhs :: Nil), arg :: Nil), witness :: Nil) =>
+          Some((ident, tpe, witness, arg, rhs))
+        case _ => None
+      }
+    }
+
+    case class State(from: List[Type], to: List[Type])
+
+    def genLens(from: Type, to: Type, term: Term): Term = {
+      (from.seal, to.seal) match {
+        case ('[$f], '[$t]) =>
+          '{ GenLens.uncurried(${term.seal.cast(using '[$f => $t])}) }.unseal
+
+      }
+    }
+
+    def selector(from: Type, to: Type, sel: List[String]): Term = {
+
+      def body(term: Term, sel: List[String]): Term = {
+        sel match {
+          case Nil => term
+          case x :: xs =>
+            body(Select.unique(term, x), xs)
+        }
+      }
+
+      (from.seal, to.seal) match {
+        case ('[$f], '[$t]) =>
+          '{ (s : $f) => ${ body('s.unseal, sel).seal.cast(using t) } }.unseal
+      }
+    }
+
+    def fieldType(sel: List[String], t: Type): Type =
+      sel match {
+        case Nil => t
+        case x :: xs =>
+          val ValDef(field, typeTree, _) = t.classSymbol.get.field(x).tree
+          fieldType(xs, typeTree.tpe)
+      }
+
+    //This is a little nasty, but sure beats having to compile by hand...
+    def compose[A, B](x: Term, y: Term)(using a: Type, b: Type): Term = {
+      (a.seal, b.seal) match {
+        case (l @ '[EOptional[$err1, $aa, $bb]], r @ '[EOptional[$err2, $cc, $dd]]) =>
+          '{ ${x.seal.cast(using l) } >>> ${ y.seal.cast(using '[EOptional[$err2, $bb, $dd]]) } }.unseal
+        case (aa, bb) =>
+          qctx.error(s"unable to compose ${aa.show} >>> ${bb.show}")
+          '{???}.unseal
+      }
+
+    }
+
+
+    def fold(term: Term)(state: State): (State, Term) =
+      term match {
+        case Function(Lambda(_, body)) =>
+          fold(body)(state)
+        case ident @ Ident(_) =>
+          state match {
+            case State(from :: Nil, _) =>
+              from.seal match {
+                case '[$a] =>
+                    (state, ' { Iso.id[$a] }.unseal)
+              }
+          }
+        case Path(sel, Ident(_)) =>
+          state match {
+            case State(from :: Nil, _) =>
+              val to = fieldType(sel, from)
+              (
+                state.copy(from = to :: state.from),
+                genLens(
+                  from,
+                  to,
+                  selector(from, to, sel)
+                )
+              )
+            case _ => ???
+          }
+        case Operator1(Ident("idx"), _ :: key :: err :: to :: Nil, witness, arg, rhs) =>
+          fold(rhs)(state) match {
+            case (State(from :: _, _), term) =>
+              (err.tpe.seal, from.seal, to.tpe.seal) match {
+                case ('[$e], '[$a], '[$b]) =>
+                  val lens = compose(
+                    term,
+                    Apply(
+                      Select.unique(witness, "index"),
+                      List(arg)
+                    )
+                  )(using term.tpe, '[EOptional[$e, $a, $b]].unseal.tpe)
+                  (
+                    state.copy(from = to.tpe :: state.from),
+                    lens
+                  )
+              }
+
+          }
+        case Operator0(Ident("?"), _ :: err :: to :: Nil, witness, rhs) =>
+          fold(rhs)(state) match {
+            case (State(from :: _, _), term) =>
+              (err.tpe.seal, from.seal, to.tpe.seal) match {
+                case ('[$e], '[$a], '[$b]) =>
+
+                  val lens = compose(
+                    term,
+                    Select.unique(witness, "attempt")
+                  )(using term.tpe, '[EOptional[$e, $a, $b]].unseal.tpe)
+                  (
+                    state.copy(from = to.tpe :: state.from),
+                    lens
+                  )
+              }
+          }
+        case Path(sel, term) =>
+          fold(term)(state) match {
+            case (State(from :: _, _), term) =>
+              val to = fieldType(sel, from)
+              val lens = genLens(
+                from,
+                to,
+                selector(from, to, sel)
+              )
+              (
+                state.copy(from = to :: state.from),
+                compose(
+                  term,
+                  lens
+                )(using term.tpe, lens.tpe)
+              )
+          }
+      }
+
+    val (_, term) = fold(getter.unseal)(
+      State(List(typeOf[S]), List(typeOf[T]))
+    )
+    term.seal
+  }
+
+
+  def apply[S] = new MkFocus[S]
+
+  class MkFocus[S] {
+    inline def apply[T](inline get: (S => T)) = ${ Focus.impl('get) }
+  }
 }

--- a/src/main/scala/optics/poly/functions/Attempt.scala
+++ b/src/main/scala/optics/poly/functions/Attempt.scala
@@ -1,0 +1,46 @@
+package optics.poly.functions
+
+import optics.poly.{EOptional, PPrism}
+import Function.const
+
+trait Attempt[From] {
+
+  type Error
+  type To
+
+  def attempt: EOptional[Error, From, To]
+
+}
+
+object Attempt {
+
+  def apply[From, Err, T](using attempt: Attempt[From] { type Error = Err; type To = T }): EOptional[Err, From, T] =
+    attempt.attempt
+
+  given [A] as Attempt[Option[A]] {
+
+    type Error = NoSuchElementException
+    type To = A
+
+    def attempt = {
+      EOptional(
+        _.map(Right(_)).getOrElse(Left(NoSuchElementException("None is not Some"))),
+        to => const(Some(to))
+      )
+    }
+  }
+
+  given [A, B] as Attempt[Either[A, B]] {
+
+    type Error = A
+    type To = B
+
+    def attempt = {
+      EOptional(
+        identity,
+        to => const(Right(to))
+      )
+    }
+  }
+
+}

--- a/src/test/scala/optics/poly/FocusTest.scala
+++ b/src/test/scala/optics/poly/FocusTest.scala
@@ -1,0 +1,49 @@
+package optics.poly
+
+import dsl._
+
+final class FocusTest extends munit.FunSuite {
+
+  case class Fub(bab: Int)
+  case class Bar(fub: Fub)
+  case class Foo(bar: Option[Bar])
+  case class Qux(foo: Either[String, Foo], moo: Map[Int, Fub])
+
+  val fooLens: EOptional[NoSuchElementException, Foo, Int] =
+    Focus[Foo](_.bar.?.fub.bab)
+
+  test("compose focus with `?`") {
+    assertEquals(
+      fooLens.getOrError(Foo(Some(Bar(Fub(1))))),
+      Right(1)
+    )
+  }
+
+  val quxLens: EOptional[NoSuchElementException | String, Qux, Int] =
+    Focus[Qux](_.foo.?.bar.?.fub.bab)
+
+  test("compose focus with nested `?`") {
+    assertEquals(
+      quxLens.getOrError(Qux(Right(Foo(Some(Bar(Fub(1))))), Map())),
+      Right(1)
+    )
+  }
+
+
+  test("compose focus with index") {
+    val lens: EOptional[NoSuchElementException, Qux, Int] = Focus[Qux](_.moo.idx(32).bab)
+    assertEquals(
+      lens.getOrError(Qux(Left("moo"), Map(32 -> Fub(32)))),
+      Right(32)
+    )
+  }
+
+  test("mixture of operators") {
+    val lens = Focus[Map[String, Qux]](_.idx("moo").foo.?.bar.?.fub)
+    assertEquals(
+      lens.getOrError(Map("moo" -> Qux(Right(Foo(Some(Bar(Fub(21))))), Map()))),
+      Right(Fub(21))
+    )
+  }
+
+}

--- a/src/test/scala/optics/poly/OptionalTest.scala
+++ b/src/test/scala/optics/poly/OptionalTest.scala
@@ -31,7 +31,7 @@ class OptionalTest extends munit.FunSuite {
     val neg = Foo(4, None)
 
     assertEquals(optLens.some.getOrError(pos), Right(true))
-    assertEquals(optLens.some.getOrError(neg), Left("None is not a Some"))
+    assertEquals(optLens.some.getOrError(neg).left.map(_.getMessage), Left("None is not a Some"))
   }
 
   test("map") {


### PR DESCRIPTION
I'd like to finish #8 before finishing this, because unfortunately, we need to be a little more involved in getting the macro to work than I'd like in dotty.

The `composeIso` is there just because I couldn't work out how to get `>>>` working properly because you need to select the correct overload and it really doesn't like it. The crux of the issues is because it's really frustrating because the macro code is typed... but we can't express the types easily in the code since the types are not reflected not properly concrete. We can absolutely do this, but I don't want to put in more work until #8 is done and dusted.

At any rate, the crux of this idea is this:

1. We have a `dsl` trait with phantom implementations `?` in this case is meant to support an arbitrary error type provided it can go to an `Either[E, A]`. The phantom trait expects the user to then compose on `A` instead.
2. We have specific macros like before such as `GenLens`. The `Focus` macro actually expands the `GenLens` macro inside of it multiple times with the correct type and a synthesized lambda!  
3. The macro strips out the `?` at the moment and pipes it through the `Iso`. it should also lift the error type, but I need to work out how that looks in the hierarchy.

My intention is for the extension trait to have `?` like rust's result, `at/index` self explanatory (we could also override get/apply, if it's more natural) and `*` for traversing (previously `each`).

Pinging @kenbot for any thoughts.